### PR TITLE
feat(i18n): translate select options to Japanese

### DIFF
--- a/features/prompt-builder/components/CompositionSection.tsx
+++ b/features/prompt-builder/components/CompositionSection.tsx
@@ -11,6 +11,7 @@ import {
 } from "../types/prompt";
 import { StepItem, ButtonToggleGroup, SelectField, SectionCard } from "./ui";
 import type { ButtonToggleOption } from "./ui";
+import type { SelectOption } from "./ui/SelectField";
 
 interface CompositionSectionProps {
   composition: ImagePrompt["composition"];
@@ -24,6 +25,22 @@ export function CompositionSection({
   const t = useTranslations("composition");
   const tc = useTranslations("common");
   const ts = useTranslations("sections");
+  const to = useTranslations("options");
+
+  // Helper to create translated select options
+  const translateOptions = (
+    options: readonly string[],
+    namespace: string
+  ): SelectOption[] =>
+    options.map((opt) => ({
+      value: opt,
+      label: to(`${namespace}.${opt}`),
+    }));
+
+  const cameraAngleOptions = translateOptions(CAMERA_ANGLES, "cameraAngles");
+  const framingOptions = translateOptions(FRAMING_OPTIONS, "framingOptions");
+  const focalPointOptions = translateOptions(FOCAL_POINT_OPTIONS, "focalPointOptions");
+  const ruleOfThirdsOptions = translateOptions(RULE_OF_THIRDS_OPTIONS, "ruleOfThirdsOptions");
 
   const DEPTH_OPTIONS: ButtonToggleOption<string>[] = [
     { value: "Shallow (Subject in focus, background blurred)", label: t("shallow") },
@@ -49,7 +66,7 @@ export function CompositionSection({
           <SelectField
             value={composition.camera_angle}
             onValueChange={(value) => onUpdate({ camera_angle: value })}
-            options={CAMERA_ANGLES}
+            options={cameraAngleOptions}
             placeholder={t("selectAngle")}
           />
         </StepItem>
@@ -62,7 +79,7 @@ export function CompositionSection({
           <SelectField
             value={composition.framing}
             onValueChange={(value) => onUpdate({ framing: value })}
-            options={FRAMING_OPTIONS}
+            options={framingOptions}
             placeholder={t("selectFraming")}
           />
         </StepItem>
@@ -101,7 +118,7 @@ export function CompositionSection({
           <SelectField
             value={composition.focal_point}
             onValueChange={(value) => onUpdate({ focal_point: value })}
-            options={FOCAL_POINT_OPTIONS}
+            options={focalPointOptions}
             placeholder={t("selectFocalPoint")}
           />
         </StepItem>
@@ -115,7 +132,7 @@ export function CompositionSection({
           <SelectField
             value={composition.rule_of_thirds_alignment}
             onValueChange={(value) => onUpdate({ rule_of_thirds_alignment: value })}
-            options={RULE_OF_THIRDS_OPTIONS}
+            options={ruleOfThirdsOptions}
             placeholder={t("selectPosition")}
           />
         </StepItem>

--- a/features/prompt-builder/components/GlobalContextSection.tsx
+++ b/features/prompt-builder/components/GlobalContextSection.tsx
@@ -19,6 +19,7 @@ import {
   SectionCard,
   ColorPickerList,
 } from "./ui";
+import type { SelectOption } from "./ui/SelectField";
 
 interface GlobalContextSectionProps {
   globalContext: ImagePrompt["global_context"];
@@ -42,8 +43,26 @@ export function GlobalContextSection({
   const t = useTranslations("context");
   const tc = useTranslations("common");
   const ts = useTranslations("sections");
+  const to = useTranslations("options");
 
   const contrastLabels = [tc("low"), tc("medium"), tc("high")] as const;
+
+  // Helper to create translated select options
+  const translateOptions = (
+    options: readonly string[],
+    namespace: string
+  ): SelectOption[] =>
+    options.map((opt) => ({
+      value: opt,
+      label: to(`${namespace}.${opt}`),
+    }));
+
+  const environmentOptions = translateOptions(ENVIRONMENT_TYPES, "environmentTypes");
+  const atmosphereOptions = translateOptions(ATMOSPHERE_OPTIONS, "atmosphereOptions");
+  const lightingSourceOptions = translateOptions(LIGHTING_SOURCES, "lightingSources");
+  const lightingQualityOptions = translateOptions(LIGHTING_QUALITIES, "lightingQualities");
+  const lightingDirectionOptions = translateOptions(LIGHTING_DIRECTIONS, "lightingDirections");
+  const colorTemperatureOptions = translateOptions(COLOR_TEMPERATURES, "colorTemperatures");
 
   const handleColorChange = (index: number, value: string) => {
     const newColors = [...globalContext.color_palette.dominant_hex_estimates];
@@ -92,7 +111,7 @@ export function GlobalContextSection({
           <SelectField
             value={globalContext.environment_type}
             onValueChange={(value) => onUpdate({ environment_type: value })}
-            options={ENVIRONMENT_TYPES}
+            options={environmentOptions}
             placeholder={t("selectEnvironment")}
           />
         </StepItem>
@@ -105,7 +124,7 @@ export function GlobalContextSection({
           <SelectField
             value={globalContext.weather_atmosphere}
             onValueChange={(value) => onUpdate({ weather_atmosphere: value })}
-            options={ATMOSPHERE_OPTIONS}
+            options={atmosphereOptions}
             placeholder={t("selectAtmosphere")}
           />
         </StepItem>
@@ -120,13 +139,13 @@ export function GlobalContextSection({
               <SelectField
                 value={globalContext.lighting.source}
                 onValueChange={(value) => onUpdateLighting({ source: value })}
-                options={LIGHTING_SOURCES}
+                options={lightingSourceOptions}
                 placeholder={t("lightingSource")}
               />
               <SelectField
                 value={globalContext.lighting.quality}
                 onValueChange={(value) => onUpdateLighting({ quality: value })}
-                options={LIGHTING_QUALITIES}
+                options={lightingQualityOptions}
                 placeholder={t("lightingQuality")}
               />
             </div>
@@ -134,13 +153,13 @@ export function GlobalContextSection({
               <SelectField
                 value={globalContext.lighting.direction}
                 onValueChange={(value) => onUpdateLighting({ direction: value })}
-                options={LIGHTING_DIRECTIONS}
+                options={lightingDirectionOptions}
                 placeholder={t("lightingDirection")}
               />
               <SelectField
                 value={globalContext.lighting.color_temperature}
                 onValueChange={(value) => onUpdateLighting({ color_temperature: value })}
-                options={COLOR_TEMPERATURES}
+                options={colorTemperatureOptions}
                 placeholder={t("colorTemperature")}
               />
             </div>

--- a/features/prompt-builder/components/MetaSection.tsx
+++ b/features/prompt-builder/components/MetaSection.tsx
@@ -5,6 +5,7 @@ import { Sliders, Sparkles, Image, ScanLine, Aperture, Volume2 } from "lucide-re
 import type { ImagePrompt } from "../types/prompt";
 import { IMAGE_TYPES, RESOLUTION_OPTIONS, LENS_TYPES } from "../types/prompt";
 import { StepItem, ButtonToggleGroup, SelectField, SectionCard } from "./ui";
+import type { SelectOption } from "./ui/SelectField";
 
 interface MetaSectionProps {
   meta: ImagePrompt["meta"];
@@ -19,9 +20,24 @@ export function MetaSection({ meta, onUpdate }: MetaSectionProps) {
   const t = useTranslations("meta");
   const tc = useTranslations("common");
   const ts = useTranslations("sections");
+  const to = useTranslations("options");
 
   const qualityLabels = [tc("low"), tc("medium"), tc("high"), t("ultra")] as const;
   const levelLabels = [tc("none"), tc("low"), tc("medium"), tc("high")] as const;
+
+  // Helper to create translated select options
+  const translateOptions = (
+    options: readonly string[],
+    namespace: string
+  ): SelectOption[] =>
+    options.map((opt) => ({
+      value: opt,
+      label: to(`${namespace}.${opt}`),
+    }));
+
+  const imageTypeOptions = translateOptions(IMAGE_TYPES, "imageTypes");
+  const resolutionOptions = translateOptions(RESOLUTION_OPTIONS, "resolutionOptions");
+  const lensOptions = translateOptions(LENS_TYPES, "lensTypes");
 
   return (
     <SectionCard icon={Sliders} title={ts("meta")}>
@@ -46,7 +62,7 @@ export function MetaSection({ meta, onUpdate }: MetaSectionProps) {
           <SelectField
             value={meta.image_type}
             onValueChange={(value) => onUpdate({ image_type: value })}
-            options={IMAGE_TYPES}
+            options={imageTypeOptions}
             placeholder={t("selectType")}
             className="w-full"
           />
@@ -60,7 +76,7 @@ export function MetaSection({ meta, onUpdate }: MetaSectionProps) {
           <SelectField
             value={meta.resolution_estimation}
             onValueChange={(value) => onUpdate({ resolution_estimation: value })}
-            options={RESOLUTION_OPTIONS}
+            options={resolutionOptions}
             placeholder={t("selectResolution")}
           />
         </StepItem>
@@ -121,7 +137,7 @@ export function MetaSection({ meta, onUpdate }: MetaSectionProps) {
                 },
               })
             }
-            options={LENS_TYPES}
+            options={lensOptions}
             placeholder={t("selectLens")}
           />
         </StepItem>

--- a/features/prompt-builder/components/ObjectEditor.tsx
+++ b/features/prompt-builder/components/ObjectEditor.tsx
@@ -35,6 +35,10 @@ const CATEGORIES: ObjectCategory[] = [
   "Other",
 ];
 
+const SIZE_OPTIONS = ["Small", "Medium", "Large"] as const;
+const DISTANCE_OPTIONS = ["Close", "Mid", "Far", "Zero (Overlay)", "Behind Subject"] as const;
+const REFLECTIVITY_OPTIONS = ["None", "Low", "Medium", "High"] as const;
+
 interface ObjectEditorProps {
   object: PromptObject;
   onUpdate: (updates: Partial<PromptObject>) => void;
@@ -50,6 +54,13 @@ export function ObjectEditor({
 }: ObjectEditorProps) {
   const t = useTranslations("objects");
   const tc = useTranslations("common");
+  const to = useTranslations("options");
+
+  // Get translated label for the current value
+  const getCategoryLabel = (value: string) => to(`objectCategories.${value}`);
+  const getSizeLabel = (value: string) => to(`objectSizes.${value}`);
+  const getDistanceLabel = (value: string) => to(`objectDistances.${value}`);
+  const getReflectivityLabel = (value: string) => to(`reflectivity.${value}`);
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -142,12 +153,12 @@ export function ObjectEditor({
             }
           >
             <SelectTrigger>
-              <SelectValue />
+              <SelectValue>{getCategoryLabel(object.category)}</SelectValue>
             </SelectTrigger>
             <SelectContent>
               {CATEGORIES.map((cat) => (
                 <SelectItem key={cat} value={cat}>
-                  {cat}
+                  {getCategoryLabel(cat)}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -165,12 +176,14 @@ export function ObjectEditor({
             }
           >
             <SelectTrigger>
-              <SelectValue />
+              <SelectValue>{getSizeLabel(object.dimensions_relative)}</SelectValue>
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="Small">{t("small")}</SelectItem>
-              <SelectItem value="Medium">{tc("medium")}</SelectItem>
-              <SelectItem value="Large">{t("large")}</SelectItem>
+              {SIZE_OPTIONS.map((size) => (
+                <SelectItem key={size} value={size}>
+                  {getSizeLabel(size)}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
@@ -186,14 +199,14 @@ export function ObjectEditor({
             }
           >
             <SelectTrigger>
-              <SelectValue />
+              <SelectValue>{getDistanceLabel(object.distance_from_camera)}</SelectValue>
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="Close">{t("close")}</SelectItem>
-              <SelectItem value="Mid">{t("mid")}</SelectItem>
-              <SelectItem value="Far">{t("far")}</SelectItem>
-              <SelectItem value="Zero (Overlay)">{t("overlay")}</SelectItem>
-              <SelectItem value="Behind Subject">{t("behind")}</SelectItem>
+              {DISTANCE_OPTIONS.map((distance) => (
+                <SelectItem key={distance} value={distance}>
+                  {getDistanceLabel(distance)}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         </div>
@@ -327,13 +340,14 @@ export function ObjectEditor({
                   }
                 >
                   <SelectTrigger>
-                    <SelectValue />
+                    <SelectValue>{getReflectivityLabel(object.surface_properties.reflectivity)}</SelectValue>
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="None">{tc("none")}</SelectItem>
-                    <SelectItem value="Low">{tc("low")}</SelectItem>
-                    <SelectItem value="Medium">{tc("medium")}</SelectItem>
-                    <SelectItem value="High">{tc("high")}</SelectItem>
+                    {REFLECTIVITY_OPTIONS.map((ref) => (
+                      <SelectItem key={ref} value={ref}>
+                        {getReflectivityLabel(ref)}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/features/prompt-builder/components/ui/SelectField.tsx
+++ b/features/prompt-builder/components/ui/SelectField.tsx
@@ -8,12 +8,23 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
 interface SelectFieldProps {
   value: string;
   onValueChange: (value: string) => void;
-  options: readonly string[];
+  options: readonly string[] | SelectOption[];
   placeholder?: string;
   className?: string;
+}
+
+function isSelectOptionArray(
+  options: readonly string[] | SelectOption[]
+): options is SelectOption[] {
+  return options.length > 0 && typeof options[0] === "object";
 }
 
 export function SelectField({
@@ -23,15 +34,24 @@ export function SelectField({
   placeholder = "Select...",
   className,
 }: SelectFieldProps) {
+  const normalizedOptions: SelectOption[] = isSelectOptionArray(options)
+    ? options
+    : options.map((opt) => ({ value: opt, label: opt }));
+
+  // Find the label for the current value to display in the trigger
+  const selectedOption = normalizedOptions.find((opt) => opt.value === value);
+
   return (
     <Select value={value} onValueChange={onValueChange}>
       <SelectTrigger className={className}>
-        <SelectValue placeholder={placeholder} />
+        <SelectValue placeholder={placeholder}>
+          {selectedOption?.label}
+        </SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {options.map((option) => (
-          <SelectItem key={option} value={option}>
-            {option}
+        {normalizedOptions.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
           </SelectItem>
         ))}
       </SelectContent>

--- a/features/prompt-builder/components/ui/index.ts
+++ b/features/prompt-builder/components/ui/index.ts
@@ -5,6 +5,7 @@ export { ButtonToggleGroup } from "./ButtonToggleGroup";
 export type { ButtonToggleOption } from "./ButtonToggleGroup";
 
 export { SelectField } from "./SelectField";
+export type { SelectOption } from "./SelectField";
 
 export { SectionCard } from "./SectionCard";
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -138,5 +138,158 @@
     "label": "Language",
     "en": "English",
     "ja": "Japanese"
+  },
+  "options": {
+    "imageTypes": {
+      "Photography": "Photography",
+      "Digital Illustration": "Digital Illustration",
+      "Mixed Media (Photography combined with Digital Illustration/Collage)": "Mixed Media (Photography + Illustration/Collage)",
+      "3D Render": "3D Render",
+      "Vector Art": "Vector Art",
+      "Painting Style": "Painting Style",
+      "Anime/Manga Style": "Anime/Manga Style"
+    },
+    "cameraAngles": {
+      "Eye-level": "Eye-level",
+      "Low-angle (looking up at subject)": "Low-angle (looking up)",
+      "High-angle (looking down at subject)": "High-angle (looking down)",
+      "Bird's eye view": "Bird's eye view",
+      "Worm's eye view": "Worm's eye view",
+      "Dutch angle": "Dutch angle",
+      "Over-the-shoulder": "Over-the-shoulder"
+    },
+    "framingOptions": {
+      "Extreme Close-up": "Extreme Close-up",
+      "Close-up (Face)": "Close-up (Face)",
+      "Medium Close-up (Head and Shoulders)": "Medium Close-up (Head & Shoulders)",
+      "Medium Shot (Waist up)": "Medium Shot (Waist up)",
+      "Medium Full Shot (Knees up)": "Medium Full Shot (Knees up)",
+      "Full Shot (Head to Toe)": "Full Shot (Head to Toe)",
+      "Wide Shot": "Wide Shot",
+      "Extreme Wide Shot": "Extreme Wide Shot"
+    },
+    "lightingSources": {
+      "Natural Sunlight": "Natural Sunlight",
+      "Artificial Studio Lighting": "Artificial Studio Lighting",
+      "Mixed (Natural + Artificial)": "Mixed (Natural + Artificial)",
+      "Window Light": "Window Light",
+      "Neon/Colored Lighting": "Neon/Colored Lighting",
+      "Ambient/Soft Lighting": "Ambient/Soft Lighting",
+      "Dramatic/High Contrast": "Dramatic/High Contrast"
+    },
+    "lightingQualities": {
+      "Soft, Diffused": "Soft, Diffused",
+      "Hard, Directional": "Hard, Directional",
+      "Rim/Backlit": "Rim/Backlit",
+      "Flat": "Flat",
+      "Dramatic": "Dramatic",
+      "Natural": "Natural"
+    },
+    "lightingDirections": {
+      "Front": "Front",
+      "Back (Backlit)": "Back (Backlit)",
+      "Left Side": "Left Side",
+      "Right Side": "Right Side",
+      "Top (Overhead)": "Top (Overhead)",
+      "Bottom (Underlit)": "Bottom (Underlit)",
+      "45° Key Light": "45° Key Light",
+      "Rim Light": "Rim Light",
+      "Split (Half/Half)": "Split (Half/Half)"
+    },
+    "colorTemperatures": {
+      "Warm (2700K - Golden Hour)": "Warm (2700K - Golden Hour)",
+      "Neutral (4000K - Daylight)": "Neutral (4000K - Daylight)",
+      "Cool (5500K - Overcast)": "Cool (5500K - Overcast)",
+      "Cold (6500K+ - Blue Hour)": "Cold (6500K+ - Blue Hour)",
+      "Mixed (Warm & Cool)": "Mixed (Warm & Cool)",
+      "Candlelight (1800K)": "Candlelight (1800K)",
+      "Tungsten (3200K)": "Tungsten (3200K)"
+    },
+    "environmentTypes": {
+      "Studio/Graphic Design Composition": "Studio/Graphic Design Composition",
+      "Indoor/Interior": "Indoor/Interior",
+      "Outdoor/Exterior": "Outdoor/Exterior",
+      "Urban/City": "Urban/City",
+      "Nature/Landscape": "Nature/Landscape",
+      "Abstract/Undefined": "Abstract/Undefined"
+    },
+    "atmosphereOptions": {
+      "Energetic, Artistic, Urban, Cool": "Energetic, Artistic, Urban, Cool",
+      "Calm, Peaceful, Serene": "Calm, Peaceful, Serene",
+      "Dark, Moody, Mysterious": "Dark, Moody, Mysterious",
+      "Bright, Cheerful, Optimistic": "Bright, Cheerful, Optimistic",
+      "Professional, Corporate, Clean": "Professional, Corporate, Clean",
+      "Romantic, Soft, Dreamy": "Romantic, Soft, Dreamy",
+      "Futuristic, Sci-fi, Tech": "Futuristic, Sci-fi, Tech"
+    },
+    "resolutionOptions": {
+      "4K (3840×2160)": "4K (3840×2160)",
+      "2K (2560×1440)": "2K (2560×1440)",
+      "Full HD (1920×1080)": "Full HD (1920×1080)",
+      "HD (1280×720)": "HD (1280×720)",
+      "Square 1:1 (1024×1024)": "Square 1:1 (1024×1024)",
+      "Portrait 3:4 (768×1024)": "Portrait 3:4 (768×1024)",
+      "Landscape 16:9 (1920×1080)": "Landscape 16:9 (1920×1080)"
+    },
+    "lensTypes": {
+      "Wide Angle (14-35mm)": "Wide Angle (14-35mm)",
+      "Standard (35-50mm)": "Standard (35-50mm)",
+      "Portrait (50-85mm)": "Portrait (50-85mm)",
+      "Telephoto (85-200mm)": "Telephoto (85-200mm)",
+      "Macro": "Macro",
+      "Fisheye": "Fisheye",
+      "Tilt-Shift": "Tilt-Shift"
+    },
+    "focalPointOptions": {
+      "Subject's Face": "Subject's Face",
+      "Subject's Eyes": "Subject's Eyes",
+      "Center of Frame": "Center of Frame",
+      "Foreground Object": "Foreground Object",
+      "Background Element": "Background Element",
+      "Product/Item": "Product/Item",
+      "Text/Logo": "Text/Logo",
+      "Leading Lines Intersection": "Leading Lines Intersection"
+    },
+    "ruleOfThirdsOptions": {
+      "Subject Center": "Subject Center",
+      "Subject Left Third": "Subject Left Third",
+      "Subject Right Third": "Subject Right Third",
+      "Subject Upper Third": "Subject Upper Third",
+      "Subject Lower Third": "Subject Lower Third",
+      "Upper-Left Intersection": "Upper-Left Intersection",
+      "Upper-Right Intersection": "Upper-Right Intersection",
+      "Lower-Left Intersection": "Lower-Left Intersection",
+      "Lower-Right Intersection": "Lower-Right Intersection"
+    },
+    "objectCategories": {
+      "Person": "Person",
+      "Apparel": "Apparel",
+      "Footwear": "Footwear",
+      "Accessory": "Accessory",
+      "Illustration/Overlay": "Illustration/Overlay",
+      "Illustration/Background Element": "Illustration/Background Element",
+      "Digital Vector": "Digital Vector",
+      "Prop": "Prop",
+      "Environment": "Environment",
+      "Other": "Other"
+    },
+    "objectSizes": {
+      "Small": "Small",
+      "Medium": "Medium",
+      "Large": "Large"
+    },
+    "objectDistances": {
+      "Close": "Close",
+      "Mid": "Mid",
+      "Far": "Far",
+      "Zero (Overlay)": "Zero (Overlay)",
+      "Behind Subject": "Behind Subject"
+    },
+    "reflectivity": {
+      "None": "None",
+      "Low": "Low",
+      "Medium": "Medium",
+      "High": "High"
+    }
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -138,5 +138,158 @@
     "label": "言語",
     "en": "English",
     "ja": "日本語"
+  },
+  "options": {
+    "imageTypes": {
+      "Photography": "写真",
+      "Digital Illustration": "デジタルイラスト",
+      "Mixed Media (Photography combined with Digital Illustration/Collage)": "ミックスメディア（写真とデジタルイラスト/コラージュの組み合わせ）",
+      "3D Render": "3Dレンダリング",
+      "Vector Art": "ベクターアート",
+      "Painting Style": "絵画スタイル",
+      "Anime/Manga Style": "アニメ/マンガスタイル"
+    },
+    "cameraAngles": {
+      "Eye-level": "アイレベル",
+      "Low-angle (looking up at subject)": "ローアングル（被写体を見上げる）",
+      "High-angle (looking down at subject)": "ハイアングル（被写体を見下ろす）",
+      "Bird's eye view": "俯瞰（バーズアイビュー）",
+      "Worm's eye view": "虫の目視点",
+      "Dutch angle": "ダッチアングル",
+      "Over-the-shoulder": "オーバーザショルダー"
+    },
+    "framingOptions": {
+      "Extreme Close-up": "エクストリームクローズアップ",
+      "Close-up (Face)": "クローズアップ（顔）",
+      "Medium Close-up (Head and Shoulders)": "ミディアムクローズアップ（頭と肩）",
+      "Medium Shot (Waist up)": "ミディアムショット（腰から上）",
+      "Medium Full Shot (Knees up)": "ミディアムフルショット（膝から上）",
+      "Full Shot (Head to Toe)": "フルショット（全身）",
+      "Wide Shot": "ワイドショット",
+      "Extreme Wide Shot": "エクストリームワイドショット"
+    },
+    "lightingSources": {
+      "Natural Sunlight": "自然光（太陽光）",
+      "Artificial Studio Lighting": "スタジオ照明（人工光）",
+      "Mixed (Natural + Artificial)": "ミックス（自然光＋人工光）",
+      "Window Light": "窓からの光",
+      "Neon/Colored Lighting": "ネオン/カラー照明",
+      "Ambient/Soft Lighting": "アンビエント/ソフト照明",
+      "Dramatic/High Contrast": "ドラマチック/ハイコントラスト"
+    },
+    "lightingQualities": {
+      "Soft, Diffused": "ソフト、拡散光",
+      "Hard, Directional": "ハード、指向性",
+      "Rim/Backlit": "リムライト/逆光",
+      "Flat": "フラット",
+      "Dramatic": "ドラマチック",
+      "Natural": "自然"
+    },
+    "lightingDirections": {
+      "Front": "正面",
+      "Back (Backlit)": "背面（逆光）",
+      "Left Side": "左サイド",
+      "Right Side": "右サイド",
+      "Top (Overhead)": "トップ（真上）",
+      "Bottom (Underlit)": "ボトム（下から）",
+      "45° Key Light": "45度キーライト",
+      "Rim Light": "リムライト",
+      "Split (Half/Half)": "スプリット（半分/半分）"
+    },
+    "colorTemperatures": {
+      "Warm (2700K - Golden Hour)": "暖色（2700K - ゴールデンアワー）",
+      "Neutral (4000K - Daylight)": "中間色（4000K - 日中）",
+      "Cool (5500K - Overcast)": "寒色（5500K - 曇天）",
+      "Cold (6500K+ - Blue Hour)": "冷色（6500K+ - ブルーアワー）",
+      "Mixed (Warm & Cool)": "ミックス（暖色＆寒色）",
+      "Candlelight (1800K)": "キャンドルライト（1800K）",
+      "Tungsten (3200K)": "タングステン（3200K）"
+    },
+    "environmentTypes": {
+      "Studio/Graphic Design Composition": "スタジオ/グラフィックデザイン構成",
+      "Indoor/Interior": "屋内/インテリア",
+      "Outdoor/Exterior": "屋外/エクステリア",
+      "Urban/City": "都市/シティ",
+      "Nature/Landscape": "自然/風景",
+      "Abstract/Undefined": "抽象的/未定義"
+    },
+    "atmosphereOptions": {
+      "Energetic, Artistic, Urban, Cool": "エネルギッシュ、アーティスティック、アーバン、クール",
+      "Calm, Peaceful, Serene": "穏やか、平和、静寂",
+      "Dark, Moody, Mysterious": "ダーク、ムーディー、ミステリアス",
+      "Bright, Cheerful, Optimistic": "明るい、陽気、楽観的",
+      "Professional, Corporate, Clean": "プロフェッショナル、コーポレート、クリーン",
+      "Romantic, Soft, Dreamy": "ロマンチック、ソフト、ドリーミー",
+      "Futuristic, Sci-fi, Tech": "フューチャリスティック、SF、テック"
+    },
+    "resolutionOptions": {
+      "4K (3840×2160)": "4K（3840×2160）",
+      "2K (2560×1440)": "2K（2560×1440）",
+      "Full HD (1920×1080)": "フルHD（1920×1080）",
+      "HD (1280×720)": "HD（1280×720）",
+      "Square 1:1 (1024×1024)": "正方形 1:1（1024×1024）",
+      "Portrait 3:4 (768×1024)": "縦長 3:4（768×1024）",
+      "Landscape 16:9 (1920×1080)": "横長 16:9（1920×1080）"
+    },
+    "lensTypes": {
+      "Wide Angle (14-35mm)": "広角（14-35mm）",
+      "Standard (35-50mm)": "標準（35-50mm）",
+      "Portrait (50-85mm)": "ポートレート（50-85mm）",
+      "Telephoto (85-200mm)": "望遠（85-200mm）",
+      "Macro": "マクロ",
+      "Fisheye": "魚眼",
+      "Tilt-Shift": "ティルトシフト"
+    },
+    "focalPointOptions": {
+      "Subject's Face": "被写体の顔",
+      "Subject's Eyes": "被写体の目",
+      "Center of Frame": "フレーム中央",
+      "Foreground Object": "前景オブジェクト",
+      "Background Element": "背景要素",
+      "Product/Item": "製品/アイテム",
+      "Text/Logo": "テキスト/ロゴ",
+      "Leading Lines Intersection": "導線の交点"
+    },
+    "ruleOfThirdsOptions": {
+      "Subject Center": "被写体中央",
+      "Subject Left Third": "被写体左3分の1",
+      "Subject Right Third": "被写体右3分の1",
+      "Subject Upper Third": "被写体上3分の1",
+      "Subject Lower Third": "被写体下3分の1",
+      "Upper-Left Intersection": "左上交点",
+      "Upper-Right Intersection": "右上交点",
+      "Lower-Left Intersection": "左下交点",
+      "Lower-Right Intersection": "右下交点"
+    },
+    "objectCategories": {
+      "Person": "人物",
+      "Apparel": "アパレル",
+      "Footwear": "フットウェア",
+      "Accessory": "アクセサリー",
+      "Illustration/Overlay": "イラスト/オーバーレイ",
+      "Illustration/Background Element": "イラスト/背景要素",
+      "Digital Vector": "デジタルベクター",
+      "Prop": "小道具",
+      "Environment": "環境",
+      "Other": "その他"
+    },
+    "objectSizes": {
+      "Small": "小",
+      "Medium": "中",
+      "Large": "大"
+    },
+    "objectDistances": {
+      "Close": "近い",
+      "Mid": "中間",
+      "Far": "遠い",
+      "Zero (Overlay)": "ゼロ（オーバーレイ）",
+      "Behind Subject": "被写体の後ろ"
+    },
+    "reflectivity": {
+      "None": "なし",
+      "Low": "低",
+      "Medium": "中",
+      "High": "高"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Translate all dropdown/select options to Japanese in the UI
- Keep English values in JSON output (for API compatibility)

## Changes
- **SelectField**: Updated to support `{value, label}` format for translated options
- **Messages files**: Added `options` namespace with translations for:
  - Image types (写真, デジタルイラスト, etc.)
  - Camera angles (アイレベル, ローアングル, etc.)
  - Framing options (クローズアップ, ワイドショット, etc.)
  - Lighting (光源, 品質, 方向, 色温度)
  - Environment & atmosphere
  - Resolution & lens types
  - Object categories, sizes, distances
  - Reflectivity levels

## Behavior
| UI Display | JSON Value |
|------------|------------|
| 写真 | Photography |
| アイレベル | Eye-level |
| 人物 | Person |

## Test plan
- [ ] Visit `/ja/` and verify all dropdowns show Japanese labels
- [ ] Visit `/en/` and verify English labels display correctly
- [ ] Generate an image and verify JSON contains English values
- [ ] Import/export JSON and verify values remain in English

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)